### PR TITLE
Ensure abort removes tween from group

### DIFF
--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -92,6 +92,8 @@ export class Tween<T> {
   abort() {
     this._stacks.length = 0;
     this._finished = true;
+    // ensure the tween is no longer tracked by its group
+    this._group?.remove(this);
     return this;
   }
 }


### PR DESCRIPTION
## Summary
- ensure `Tween.abort()` removes the tween from its group
- keep group cleanup working via existing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405e0b7d14833283b6330e5f1807ac