### PR TITLE
Improve abort test behavior

### DIFF
--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -92,6 +92,7 @@ export class Tween<T> {
   abort() {
     this._stacks.length = 0;
     this._finished = true;
+    this._group?.remove(this);
     return this;
   }
 }

--- a/src/Tween.ts
+++ b/src/Tween.ts
@@ -92,6 +92,7 @@ export class Tween<T> {
   abort() {
     this._stacks.length = 0;
     this._finished = true;
+    // ensure the tween is no longer tracked by its group
     this._group?.remove(this);
     return this;
   }

--- a/test/Tween.test.ts
+++ b/test/Tween.test.ts
@@ -119,14 +119,18 @@ describe('Tween', () => {
 
   test('abort', () => {
     const obj = { x: 0 };
-    const tween = new Tween(obj).group(globalGroup).to({ x: 100 }, 10).start();
+    const group = new Group();
+    const tween = new Tween(obj).group(group).to({ x: 100 }, 10).start();
     expect(obj.x).toBe(0);
+    expect(group.length).toBe(1);
 
-    globalGroup.update();
+    group.update();
     expect(obj.x).toBe(10);
 
     tween.abort();
-    globalGroup.update();
+    expect(group.length).toBe(0);
+
+    group.update();
     expect(obj.x).toBe(10);
   });
 


### PR DESCRIPTION
## Summary
- remove tween from group when aborting
- check group length shrinks immediately in abort test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405e2eee6c833286d5ec6ffd587245